### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 1.0.1
+
+* Fixed CI errors, encodestring is deprecated alias of encodebytes
+
 # 1.0.0
 
 * Drop Python 2.7 support

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -15,7 +15,7 @@ class BaseAction(Action):
         self.url = "{}:{}/rest/items".format(self.hostname, self.port)
 
         if self.username and self.password:
-            self.auth = base64.encodestring(
+            self.auth = base64.encodebytes(
                 '%s:%s' % (self.username, self.password)).replace('\n', '')
 
     def _headers(self):

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - iot
   - smart home
   - home automation
-version: 1.0.0
+version: 1.0.1
 python_versions:
   - "3"
 author: James Fryman


### PR DESCRIPTION
Fixed files to work with latest CI updates:

- `encodestring` is deprecated alias of `encodebytes` that was removed in Python 3.9
- https://docs.python.org/3.8/library/base64.html#base64.encodestring